### PR TITLE
Makes indexeddb.open() provide some kind of database upon success

### DIFF
--- a/indexeddb.js
+++ b/indexeddb.js
@@ -413,7 +413,16 @@ var mockIndexedDBDatabase = {
 var mockIndexedDBOpenDBRequest = {
 	callSuccessHandler: function () {
 		if (this.onsuccess) {
-			var event = new CustomEvent("success", { bubbles: false, cancelable: true });
+			
+			var event = {
+				'type' : 'success',
+				'bubbles' : false,
+				'cancelable' : true,
+				'target' : {
+					'result' : mockIndexedDBDatabase
+				}
+			};
+			
 			this.onsuccess(event);
 		}
 	},

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,64 @@
+// Karma configuration
+// Generated on Wed Aug 19 2015 01:21:36 GMT-0400 (EDT)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['browserify', 'jasmine'],
+
+    // list of files / patterns to load in the browser
+    files: [
+	  'test/**/*Spec.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+        'test/**/*Spec.js': [ 'browserify' ]
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  })
+}

--- a/test/indexeddbSpec.js
+++ b/test/indexeddbSpec.js
@@ -1,0 +1,16 @@
+
+var idbMock = require('../indexeddb.js');
+
+describe('mock.open', function() { 
+	iit('should produce some kind of IDBDatabase mock', function(done) {
+		idbMock.reset();
+		idbMock.mock.open('somedb', 1).onsuccess = function(ev) {
+			expect(ev.target).not.toBe(null);
+			
+			if (ev.target)
+				expect(ev.target.result).not.toBe(null);
+			done();
+		};
+	});
+});
+


### PR DESCRIPTION
Currently it appears this library provides nothing to those who request a DB with indexeddb.open(). This change allows the library to provide a mocked DB to the tested code even if no migration is in progress. Basic Karma/Jasmine test added to verify, test fails prior to functional change and passes afterwards.
