### PR TITLE
Add `get` method to store

### DIFF
--- a/indexeddb.js
+++ b/indexeddb.js
@@ -274,6 +274,11 @@ var mockIndexedDBStore = {
 		return mockIndexedDBTransaction;
 	},
 
+	get: function (key) {
+		mockIndexedDBTransaction.callCompleteHandler();
+		return mockIndexedDBTransaction;
+	},
+
 	// for delete, the listeners are attached to a request returned from the store.
 	delete: function (data_id) {
 		if (mockIndexedDBTestFlags.canDelete === true) {


### PR DESCRIPTION
The `get` method is used in [idb-keyval](https://github.com/jakearchibald/idb-keyval),
so my tests are failing without this method.